### PR TITLE
Support Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install ntp service and set default ntp servers for the netherlands.
 Requirements
 ------------
 
-Debian Wheezy with the package python-pycurl and python-software-properties installed.
+Debian Wheezy/Jessie/Stretch with the package python-pycurl and python-software-properties installed.
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example Playbook
 License
 -------
 
-LGPL
+LGPL-3.0
 
 Author Information
 ------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
     versions:
       - wheezy
       - jessie
+      - stretch
   categories:
     - system
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
   description: Install ntp service ans set default ntp servers
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.4
   platforms:
   - name: Debian


### PR DESCRIPTION
Add up to Stretch to supported Debian versions & Specify license version (LGPL-3.0).

After merge I recommend tagging `v1.0.2`.